### PR TITLE
Security update

### DIFF
--- a/nsupdate-client
+++ b/nsupdate-client
@@ -80,7 +80,11 @@ fi
 
 if [ "$DEST" = "external" ]; then
   echo "> Getting IP address..."
-  DEST=$(curl -s http://bot.whatismyipaddress.com)
+  DEST=$(curl -s https://bot.whatismyipaddress.com)
+  if ! echo "$DEST" | grep -Eq "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"; then
+    echo "Error: Did not receive a valid IP"
+    exit
+  fi
 elif [[ "$DEST" == *if_* ]]; then
   echo "> Getting IP address..."
   IFACE=$(echo "$DEST" | sed 's/if_//g')


### PR DESCRIPTION
This should improve the security of `nsupdate-client` in two ways:

* Fetch IP address not via http (which is susceptible to MITM attacks)
* Validate the fetched IP address, before including it in the update to prevent sending arbitrary updates in case the server at `bot.whatismyipaddress.com` git compromized.

There is still an exploitable race condition by using `/tmp/$REC.tmp` which can be exploited by creating this file first, but the attacker needs to be authenticated on the machine running nsupdate-client, so I can live with that for now.